### PR TITLE
Fix compilation errors in VS, add move constructor and assignment operator

### DIFF
--- a/BitmapPlusPlus.hpp
+++ b/BitmapPlusPlus.hpp
@@ -50,10 +50,10 @@ namespace bmp {
     constexpr Pixel(std::uint8_t red, std::uint8_t green, std::uint8_t blue) noexcept: r(red), g(green), b(blue) {}
 
     constexpr bool operator==(const Pixel other) const noexcept {
-      return r == other.r and g == other.g and b == other.b;
+      return r == other.r && g == other.g && b == other.b;
     }
 
-    constexpr bool operator!=(const Pixel other) const noexcept { return not((*this) == other); }
+    constexpr bool operator!=(const Pixel other) const noexcept { return !((*this) == other); }
   };
 
   static_assert(sizeof(Pixel) == 3, "Bitmap Pixel size must be 3 bytes");

--- a/BitmapPlusPlus.hpp
+++ b/BitmapPlusPlus.hpp
@@ -8,7 +8,8 @@
 #include <cstddef>   // std::size_t
 #include <string>    // std::string
 #include <cstring>   // std::memcmp
-#include <exception> // std::exception
+#include <stdexcept> // std::runtime_error
+#include <utility>   // std::exchange
 
 namespace bmp {
   // Magic number for Bitmap .bmp 24 bpp files (24/8 = 3 = rgb colors only)
@@ -123,6 +124,12 @@ namespace bmp {
     }
 
     Bitmap(const Bitmap &other) = default; // Copy Constructor
+
+    Bitmap(Bitmap &&other) noexcept
+      : m_pixels(std::move(other.m_pixels)),
+        m_width(std::exchange(other.m_width, 0)),
+        m_height(std::exchange(other.m_height, 0)) {
+    }
 
     virtual ~Bitmap() noexcept {
       m_pixels.clear();
@@ -400,12 +407,21 @@ namespace bmp {
 
     bool operator!=(const Bitmap &image) const { return !(*this == image); }
 
-    Bitmap &operator=(const Bitmap &image) // Move assignment operator
+    Bitmap &operator=(const Bitmap &image) // Copy assignment operator
     {
       if (this != &image) {
         m_width = image.m_width;
         m_height = image.m_height;
         m_pixels = image.m_pixels;
+      }
+      return *this;
+    }
+
+    Bitmap &operator=(Bitmap &&image) noexcept {
+      if (this != &image) {
+        m_pixels = std::move(image.m_pixels);
+        m_width = std::exchange(image.m_width, 0);
+        m_height = std::exchange(image.m_height, 0);
       }
       return *this;
     }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 project(BitmapPlusPlus VERSION "1.0.1" DESCRIPTION "Simple and Fast header only Bitmap (BMP) C++ library" LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
 
 # Examples
 option(BPP_BUILD_EXAMPLES "Requires BPP to build all examples inside examples/ folder." ON)


### PR DESCRIPTION
Fixes #2

Besides fixing compilation in VS, I have also added a move constructor and a move assignment operator to the `Bitmap` class. Now the rule of 5 is satisfied and the code may perform better in specific circumstances.